### PR TITLE
Add summary line to gemspec

### DIFF
--- a/choir.gemspec
+++ b/choir.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Neil Pullman"]
   gem.email         = ["neil@descend.org"]
   gem.description   = %q{ Basic API wrapper for choir.io }
+  gem.summary       = gem.description
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
``` sh
$ gem build choir.gemspec
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    missing value for attribute summary
```
